### PR TITLE
Add timezone & model_output properties to admin schema

### DIFF
--- a/admin-schema.json
+++ b/admin-schema.json
@@ -77,6 +77,16 @@
             "description": "One or more citations for the hub.",
             "type": "string",
             "example": "Cramer, E.Y., Huang, Y., Wang, Y. et al. The United States COVID-19 Forecast Hub dataset. Sci Data 9, 462 (2022). https://doi.org/10.1038/s41597-022-01517-w"
+        },
+        "timezone": {
+            "description": "Hub timezone in UTC format. Used for determining exact time of submission deadlines.",
+            "examples": [
+                "UTC+1",
+                "UTC-03",
+                "UTC+0530"
+            ],
+            "type": "string",
+            "pattern": "UTC[+-][0-9]{1,4}"
         }
     },
     "required": [

--- a/admin-schema.json
+++ b/admin-schema.json
@@ -102,6 +102,7 @@
         "name",
         "maintainer",
         "contact",
-        "repository_url"
+        "repository_url",
+        "timezone"
     ]
 }

--- a/admin-schema.json
+++ b/admin-schema.json
@@ -87,6 +87,15 @@
             ],
             "type": "string",
             "pattern": "UTC[+-][0-9]{1,4}"
+        },
+        "model_output_dir": {
+            "description": "Relative path, with respect to the root of hub, to directory containing model output data. If property not supplied, the default path `model_output/` assumed",
+            "default": "model_output",
+            "example": [
+                "forecasts",
+                "data/model_output"
+            ],
+            "type": "string"
         }
     },
     "required": [

--- a/admin-schema.json
+++ b/admin-schema.json
@@ -7,12 +7,12 @@
         "name": {
             "description": "The name of the hub.",
             "type": "string",
-            "example": "US COVID-19 Forecast Hub​"
+            "examples": "US COVID-19 Forecast Hub​"
         },
         "maintainer": {
             "description": "The entity that maintains and runs the hub.",
             "type": "string",
-            "example": "The Consortium of Infectious Disease Modeling Hubs"
+            "examples": "The Consortium of Infectious Disease Modeling Hubs"
         },
         "contact": {
             "description": "The name and email of a human being who serves as a point of contact for the hub.",
@@ -37,12 +37,12 @@
         "repository_url": {
             "description": "The url for the hub repository.",
             "type": "string",
-            "example": "https://github.com/reichlab/covid19-forecast-hub"
+            "examples": "https://github.com/reichlab/covid19-forecast-hub"
         },
         "zoltar_project_id": {
             "description": "The project id of the Hub in Zoltar",
             "type": "integer",
-            "example": 44
+            "examples": 44
         },
         "hub_models": {
             "description": "Array of ensemble and baseline models produced by the hub",
@@ -76,7 +76,7 @@
         "citation": {
             "description": "One or more citations for the hub.",
             "type": "string",
-            "example": "Cramer, E.Y., Huang, Y., Wang, Y. et al. The United States COVID-19 Forecast Hub dataset. Sci Data 9, 462 (2022). https://doi.org/10.1038/s41597-022-01517-w"
+            "examples": "Cramer, E.Y., Huang, Y., Wang, Y. et al. The United States COVID-19 Forecast Hub dataset. Sci Data 9, 462 (2022). https://doi.org/10.1038/s41597-022-01517-w"
         },
         "timezone": {
             "description": "Hub timezone in UTC format. Used for determining exact time of submission deadlines.",
@@ -91,7 +91,7 @@
         "model_output_dir": {
             "description": "Relative path, with respect to the root of hub, to directory containing model output data. If property not supplied, the default path `model_output/` assumed",
             "default": "model_output",
-            "example": [
+            "examples": [
                 "forecasts",
                 "data/model_output"
             ],


### PR DESCRIPTION
- Resolves #20 
- Resolves #4 

## Couple of questions:
- How should we handle daylight savings? Although I've gone for UTC, I'm now questioning it as it's very difficult to account for daylight savings as not all countries observe them and those who do do not change on the same day, which itself varies form year to year! Perhaps the safest is to actually use [TZ database names](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (e.g. `Europe/London`), which are location based. R can use these to convert dates to other timezones, accounting for daylight savings. It does mean a really long list of potential valid values in the schema though. Have a look at https://github.com/Infectious-Disease-Modeling-Hubs/schemas/pull/24 for a possible implementation of this proposal.
- Are we making timezone required? I'm opting for yes for now.
- Do we want any validation of valid characters in the `model_output_dir` property?