### PR TITLE
Fix typo on required cloud field

### DIFF
--- a/v2.0.1/admin-schema.json
+++ b/v2.0.1/admin-schema.json
@@ -646,7 +646,7 @@
                 "enabled": {"type": "boolean"},
                 "host": {
                     "type": "object",
-                    "required": ["name", "storage_servce", "storage_location"],
+                    "required": ["name", "storage_service", "storage_location"],
                     "properties": {
                         "name": {
                             "description": "Name of the cloud storage provider.",


### PR DESCRIPTION
Didn't catch this one because I tested the validations on the original version of the v2.0.1 PR and didn't re-test when adding additional properties based on feedback.

I _think_ the fix here is to get this reviewed and merged, and then update the commit referenced by the v2.0.1 tag, but please let me know if that's not correct!