### PR TITLE
corrected 'repository_url' to 'repository' as 'required'

### DIFF
--- a/v3.0.0/admin-schema.json
+++ b/v3.0.0/admin-schema.json
@@ -700,7 +700,7 @@
         "name",
         "maintainer",
         "contact",
-        "repository_url",
+        "repository",
         "file_format",
         "timezone"
     ],


### PR DESCRIPTION
Maybe this is a correct fix if `repository_url` is gonna be deprecated