### PR TITLE
add read all permissions to diff commenter

### DIFF
--- a/.github/workflows/comment-diff.yaml
+++ b/.github/workflows/comment-diff.yaml
@@ -4,6 +4,8 @@ on:
   issue_comment:
     types: [created]
 
+permissions: read-all
+
 jobs:
   comment-changed-workflow:
     name: 'Comment Spec Diff'


### PR DESCRIPTION
We were having trouble commenting the diff in #103 and have no clue why it's not working. Maybe this will fix it?